### PR TITLE
use basic as layout_engine

### DIFF
--- a/wordcloud/wordcloud.py
+++ b/wordcloud/wordcloud.py
@@ -503,7 +503,7 @@ class WordCloud(object):
                     # font-size went too small
                     break
                 # try to find a position
-                font = ImageFont.truetype(self.font_path, font_size)
+                font = ImageFont.truetype(self.font_path, font_size, layout_engine=ImageFont.Layout.BASIC)
                 # transpose font optionally
                 transposed_font = ImageFont.TransposedFont(
                     font, orientation=orientation)
@@ -661,7 +661,8 @@ class WordCloud(object):
         draw = ImageDraw.Draw(img)
         for (word, count), font_size, position, orientation, color in self.layout_:
             font = ImageFont.truetype(self.font_path,
-                                      int(font_size * self.scale))
+                                      int(font_size * self.scale),
+                                      layout_engine=ImageFont.Layout.BASIC)
             transposed_font = ImageFont.TransposedFont(
                 font, orientation=orientation)
             pos = (int(position[1] * self.scale),
@@ -816,7 +817,7 @@ class WordCloud(object):
         result = []
 
         # Get font information
-        font = ImageFont.truetype(self.font_path, int(max_font_size * self.scale))
+        font = ImageFont.truetype(self.font_path, int(max_font_size * self.scale), layout_engine=ImageFont.Layout.BASIC)
         raw_font_family, raw_font_style = font.getname()
         # TODO properly escape/quote this name?
         font_family = repr(raw_font_family)
@@ -953,7 +954,7 @@ class WordCloud(object):
             y *= self.scale
 
             # Get text metrics
-            font = ImageFont.truetype(self.font_path, int(font_size * self.scale))
+            font = ImageFont.truetype(self.font_path, int(font_size * self.scale), layout_engine=ImageFont.Layout.BASIC)
             (size_x, size_y), (offset_x, offset_y) = font.font.getsize(word)
             ascent, descent = font.getmetrics()
 


### PR DESCRIPTION
Some systems do not have RAQM installed, which can affect the accuracy of text size calculations by Pillow, ultimately influencing text placement. As a result, the generated word cloud may differ depending on whether RAQM is available on the system. To ensure consistency, use ImageFont.BASIC as the layout_engine in the ImageFont.truetype() function.

RAQM (Rendering Arabic with the help of Qahir and FriBidi) is a library that provides advanced text layout capabilities, such as proper handling of bidirectional text and accurate text shaping for complex scripts. If RAQM is not installed, Pillow falls back to simpler text rendering methods, which may lead to differences in text positioning and appearance.